### PR TITLE
Fix toolbar course display

### DIFF
--- a/app/src/AppWrapper.tsx
+++ b/app/src/AppWrapper.tsx
@@ -4,17 +4,21 @@ import { store, persistor } from './configureStore'
 import { fetchData } from './actions'
 import App from './App'
 
-const previousMeta = store.getState().meta
-store.dispatch(fetchData(previousMeta))
-
 export function wrapApp(AppComponent: typeof App) {
-  const AppWraper = () => (
-    <Provider store={store}>
-      <PersistGate persistor={persistor} loading={null}>
-        <AppComponent />
-      </PersistGate>
-    </Provider>
-  )
+  const AppWraper = () => {
+    const handleBeforeLift = () => {
+      const previousMeta = store.getState().meta
+      store.dispatch(fetchData(previousMeta))
+    }
+
+    return (
+      <Provider store={store}>
+        <PersistGate persistor={persistor} loading={null} onBeforeLift={handleBeforeLift}>
+          <AppComponent />
+        </PersistGate>
+      </Provider>
+    )
+  }
   return AppWraper
 }
 

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -54,6 +54,7 @@ const CourseListComponent: FC<Props> = (props: Props) => {
   const [showPopover, setShowPopover] = useState<PopoverState>()
   const reducedMotion = useSelector((state: RootState) => state.options.reducedMotion)
   const { chosen, custom, additional, onColourChange } = props
+  console.log(chosen, custom)
   const allCourses = useMemo(
     () => [...chosen, ...custom, ...additional],
     [chosen, custom, additional],
@@ -83,7 +84,7 @@ const CourseListComponent: FC<Props> = (props: Props) => {
     },
     [showPopover, handleHidePopover, onColourChange],
   )
-
+  // console.log(allCourses) TODO 
   return (
     <List className={classes.root} disablePadding id="course-display">
       <TransitionGroup>
@@ -122,7 +123,6 @@ const CourseListComponent: FC<Props> = (props: Props) => {
           </Collapse>
         ))}
       </TransitionGroup>
-      <Divider light />
 
       <Popover
         open={showPopover !== undefined}

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -122,7 +122,7 @@ const CourseListComponent: FC<Props> = (props: Props) => {
           </Collapse>
         ))}
       </TransitionGroup>
-
+      <Divider light />
       <Popover
         open={showPopover !== undefined}
         anchorEl={showPopover ? showPopover.target : undefined}

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -54,7 +54,6 @@ const CourseListComponent: FC<Props> = (props: Props) => {
   const [showPopover, setShowPopover] = useState<PopoverState>()
   const reducedMotion = useSelector((state: RootState) => state.options.reducedMotion)
   const { chosen, custom, additional, onColourChange } = props
-  console.log(chosen, custom)
   const allCourses = useMemo(
     () => [...chosen, ...custom, ...additional],
     [chosen, custom, additional],
@@ -84,7 +83,7 @@ const CourseListComponent: FC<Props> = (props: Props) => {
     },
     [showPopover, handleHidePopover, onColourChange],
   )
-  // console.log(allCourses) TODO 
+
   return (
     <List className={classes.root} disablePadding id="course-display">
       <TransitionGroup>

--- a/app/src/reducers/courses.ts
+++ b/app/src/reducers/courses.ts
@@ -45,6 +45,7 @@ export function chosen(
   state: CourseId[] = [],
   action: AllActions,
 ): CourseId[] {
+  console.log(action)
   if (action.type === ADD_COURSE && !action.course.isCustom) {
     return [
       ...state,

--- a/app/src/reducers/courses.ts
+++ b/app/src/reducers/courses.ts
@@ -45,7 +45,6 @@ export function chosen(
   state: CourseId[] = [],
   action: AllActions,
 ): CourseId[] {
-
   if (action.type === ADD_COURSE && !action.course.isCustom) {
     return [
       ...state,

--- a/app/src/reducers/courses.ts
+++ b/app/src/reducers/courses.ts
@@ -45,7 +45,7 @@ export function chosen(
   state: CourseId[] = [],
   action: AllActions,
 ): CourseId[] {
-  console.log(action)
+
   if (action.type === ADD_COURSE && !action.course.isCustom) {
     return [
       ...state,


### PR DESCRIPTION
After selecting courses, refreshing the page didn't result in those same courses appearing in the course selection area above the "Campus Bible Study" Selection. 

This fixes that. 