### PR TITLE
Fix Custom Event Display

### DIFF
--- a/app/src/reducers/timetables.ts
+++ b/app/src/reducers/timetables.ts
@@ -38,7 +38,11 @@ function findMissingSessions(
 ): Set<SessionId> {
   const sessionsToRemove = new Set<SessionId>()
   for (const [sessionId, placement] of timetableData) {
-    const course = courses.get(placement.session.course)
+    const courseId = placement.session.course
+    const course = courses.get(courseId)
+    if (courseId.startsWith('custom_')) {
+      continue
+    }
     if (course === undefined) {
       sessionsToRemove.add(sessionId)
     } else {


### PR DESCRIPTION
Good morning. 

Previously, crossangles.app does not display custom events upon refreshing the page. This is fixed by modifying app behavior to skip removing sessions that begin with the custom tag `custom_`, letting the fronted display custom events upon entering the page.