### PR TITLE
Update signupValidFor term from 1 to 2

### DIFF
--- a/scraper/data/unsw.ts
+++ b/scraper/data/unsw.ts
@@ -37,7 +37,7 @@ const BASE_UNSW_DATA: CampusAdditional<CBSComponent> = {
       metadata: {
         ...CBS_BASE_META,
         signupURL: 'https://campusbiblestudy.org/signup',
-        signupValidFor: [{ year: 2026, term: 1 }],
+        signupValidFor: [{ year: 2026, term: 2 }],
       },
       streams: [
         {


### PR DESCRIPTION
Just FYI, this field needs to be updated when the signup form is ready for the next term so that the "sign up for CBS" button is displayed correctly (it doesn't display otherwise in case the signup form isn't yet ready when the new timetable data is released from UNSW).

I'm assuming based on the timing and what the signup form looks like that it is ready now. If so, feel free to merge this PR 🙂