### PR TITLE
Add access logging for course data bucket

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -62,6 +62,24 @@ export default $config({
       }
     })
 
+    // Access logs bucket
+    const logsBucket = new sst.aws.Bucket("AccessLogs", {
+      transform: {
+        bucket: args => {
+          args.bucket = isProd
+            ? "crossangles-access-logs"
+            : `crossangles-access-logs-${stage}`
+          args.forceDestroy = false
+        }
+      }
+    })
+
+    new aws.s3.BucketLoggingV2("CourseDataLogging", {
+      bucket: bucket.name,
+      targetBucket: logsBucket.name,
+      targetPrefix: "course-data-logs/",
+    })
+
     // 2. Scraper
     const scraper = new sst.aws.Function("Scraper", {
       handler: "scraper/lambda.handler",


### PR DESCRIPTION
Cross-region data transfer costs on AWS are up ~97% since mid-May. These logs should help identify the cause.