### PR TITLE
Align staging and production cache times for data

### DIFF
--- a/scraper/writer/S3Writer.ts
+++ b/scraper/writer/S3Writer.ts
@@ -50,7 +50,7 @@ export class S3Writer implements Writer {
   }
 
   private upload(content: string, additionalParams?: Partial<PutObjectRequest>) {
-    const maxAge = ENVIRONMENT === 'staging' ? 600 : 7200
+    const maxAge = 7200
     const command = new PutObjectCommand({
       Bucket: this.bucket,
       Key: this.path,

--- a/scraper/writer/S3Writer.ts
+++ b/scraper/writer/S3Writer.ts
@@ -7,8 +7,6 @@ import {
 import crypto from 'crypto'
 import { Writer } from './Writer'
 
-const ENVIRONMENT = process.env.ENVIRONMENT || ''
-
 export class S3Writer implements Writer {
   private readonly s3 = new S3Client()
 

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -87,7 +87,6 @@ export default $config({
       environment: {
         S3_OUTPUT_BUCKET: bucketName,
         STATE_TABLE: `ScraperState_${stage}`,
-        ENVIRONMENT: stage,
       },
       timeout: "5 minutes",
       memory: "2048 MB",


### PR DESCRIPTION
The timing of the increase in cross-region data costs coincides with the time when Google temporarily decided to cache the staging site instead of the main site. This may have led to the staging site being picked up by additional users/bots/scrapers since. Because the cache time was much lower for the staging data, this could explain the sudden increase in cross-region data transfer.